### PR TITLE
Add base Mercado Pago integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Mercado Pago Access Token for server-side requests
+MERCADOPAGO_ACCESS_TOKEN=
+
+# Public key for Mercado Pago JS (client-side). Prefix with NEXT_PUBLIC_ so it's exposed to the browser
+NEXT_PUBLIC_MERCADOPAGO_PUBLIC_KEY=

--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { getMercadoPagoClient } from "@/lib/mercadopago"
 
 // Simulamos MercadoPago para el demo - en producción usar MercadoPago real
 const simulateMercadoPagoCheckout = async (productData: any) => {
@@ -36,20 +37,16 @@ export async function POST(request: NextRequest) {
       userAgent: request.headers.get("user-agent"),
     })
 
-    // Verificar si tenemos el token de MercadoPago
-    if (process.env.MERCADOPAGO_ACCESS_TOKEN) {
+    // Verificar si tenemos el cliente de MercadoPago configurado
+    const mpClient = getMercadoPagoClient()
+
+    if (mpClient) {
       console.log("Usando MercadoPago real con token configurado")
 
       try {
-        // Importar MercadoPago SDK dinámicamente
-        const { MercadoPagoConfig, Preference } = await import("mercadopago")
+        const { Preference } = await import("mercadopago")
 
-        const client = new MercadoPagoConfig({
-          accessToken: process.env.MERCADOPAGO_ACCESS_TOKEN,
-          options: { timeout: 5000 },
-        })
-
-        const preference = new Preference(client)
+        const preference = new Preference(mpClient)
 
         const preferenceData = {
           items: [

--- a/app/api/webhooks/mercadopago/route.ts
+++ b/app/api/webhooks/mercadopago/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { getMercadoPagoClient } from "@/lib/mercadopago"
 
 export async function POST(request: NextRequest) {
   try {
@@ -40,16 +41,14 @@ async function handlePaymentNotification(paymentId: string) {
   try {
     console.log("Procesando notificación de pago:", paymentId)
 
+    const mpClient = getMercadoPagoClient()
+
     // Si tenemos el token de MercadoPago, obtener detalles reales
-    if (process.env.MERCADOPAGO_ACCESS_TOKEN) {
+    if (mpClient) {
       try {
-        const { MercadoPagoConfig, Payment } = await import("mercadopago")
+        const { Payment } = await import("mercadopago")
 
-        const client = new MercadoPagoConfig({
-          accessToken: process.env.MERCADOPAGO_ACCESS_TOKEN,
-        })
-
-        const payment = new Payment(client)
+        const payment = new Payment(mpClient)
         const paymentData = await payment.get({ id: paymentId })
 
         console.log("Datos del pago obtenidos:", {

--- a/lib/mercadopago.ts
+++ b/lib/mercadopago.ts
@@ -1,0 +1,22 @@
+import { MercadoPagoConfig } from "mercadopago"
+
+let client: MercadoPagoConfig | null = null
+
+export function getMercadoPagoClient() {
+  if (client) {
+    return client
+  }
+
+  const accessToken = process.env.MERCADOPAGO_ACCESS_TOKEN
+  if (!accessToken) {
+    console.warn("MERCADOPAGO_ACCESS_TOKEN not set; Mercado Pago client disabled")
+    return null
+  }
+
+  client = new MercadoPagoConfig({
+    accessToken,
+    options: { timeout: 5000 },
+  })
+
+  return client
+}


### PR DESCRIPTION
## Summary
- set up Mercado Pago helper and config
- update checkout and webhook API routes to use Mercado Pago client
- provide `.env.example` with Mercado Pago variables

## Testing
- `pnpm lint` *(fails: ESLint config prompt)*
- `pnpm build` *(fails: couldn't fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840dc2ef530832c9e252c6a8222c82c