### PR TITLE
Update product visuals

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -201,7 +201,7 @@ export default function EstudioVePage() {
           className="absolute inset-0 overflow-hidden pointer-events-none"
         >
           <div className="absolute top-1/4 right-1/4 w-96 h-96 bg-orange-500/10 rounded-full blur-3xl animate-pulse" />
-          <div className="absolute bottom-1/4 left-1/4 w-64 h-64 bg-yellow-400/10 rounded-full blur-2xl animate-pulse delay-1000" />
+          <div className="absolute bottom-1/4 left-1/4 w-64 h-64 bg-orange-400/10 rounded-full blur-2xl animate-pulse delay-1000" />
         </motion.div>
 
         {/* Contenido principal */}
@@ -235,14 +235,14 @@ export default function EstudioVePage() {
               <div className="absolute inset-0 bg-gradient-to-r from-orange-600 to-orange-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </button>
 
-            <button className="group relative overflow-hidden bg-gradient-to-r from-yellow-400 to-yellow-500 hover:from-yellow-500 hover:to-yellow-600 text-black px-8 py-4 rounded-2xl text-lg font-semibold shadow-2xl transition-all duration-300 transform hover:scale-105 hover:shadow-yellow-500/25">
+            <button className="group relative overflow-hidden bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white px-8 py-4 rounded-2xl text-lg font-semibold shadow-2xl transition-all duration-300 transform hover:scale-105 hover:shadow-orange-500/25">
               <span className="relative z-10 flex items-center justify-center gap-2">
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
                 Agendar mentoría
               </span>
-              <div className="absolute inset-0 bg-gradient-to-r from-yellow-500 to-yellow-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              <div className="absolute inset-0 bg-gradient-to-r from-orange-600 to-orange-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </button>
           </div>
 

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { CategoryShield } from "@/components/category-shield"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import {
@@ -146,6 +147,11 @@ const products: Product[] = [
 
 const categories = ["Todos", "Ebook", "Plantillas", "Curso"]
 const types = ["Todos", "ebook", "template", "course", "tool"]
+const shieldColors: Record<string, string> = {
+  Ebook: "fill-blue-600",
+  Plantillas: "fill-green-600",
+  Curso: "fill-orange-600",
+}
 
 export default function ProductosPage() {
   const [filteredProducts, setFilteredProducts] = useState(products)
@@ -510,7 +516,11 @@ export default function ProductosPage() {
                         alt={product.name}
                         className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-500"
                       />
-                      <Badge className="absolute top-4 left-4 bg-primary text-white">{product.category}</Badge>
+                      <CategoryShield
+                        className="absolute top-4 left-4"
+                        label={product.category}
+                        color={shieldColors[product.category]}
+                      />
                       <div className="absolute top-4 right-4">
                         {product.type === "ebook" && <BookOpen className="h-5 w-5 text-white" />}
                         {product.type === "template" && <FileText className="h-5 w-5 text-white" />}
@@ -522,7 +532,7 @@ export default function ProductosPage() {
                     <div className="p-6">
                       <div className="flex items-center gap-2 mb-3">
                         <div className="flex items-center gap-1">
-                          <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                          <Star className="h-4 w-4 fill-primary text-primary" />
                           <span className="text-sm font-medium">{product.rating}</span>
                         </div>
                         <div className="flex items-center gap-1 text-charcoal-500 dark:text-charcoal-400">

--- a/app/servicios/page.tsx
+++ b/app/servicios/page.tsx
@@ -567,7 +567,7 @@ export default function ServiciosPage() {
                         {/* Service Info */}
                         <div className="flex items-center gap-4 mb-4 text-sm text-charcoal-500 dark:text-charcoal-400">
                           <div className="flex items-center gap-1">
-                            <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                            <Star className="h-4 w-4 fill-primary text-primary" />
                             <span>{service.rating}</span>
                           </div>
                           <div className="flex items-center gap-1">

--- a/components/category-shield.tsx
+++ b/components/category-shield.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import { cn } from "@/lib/utils"
+
+interface CategoryShieldProps {
+  label: string
+  color?: string
+  className?: string
+}
+
+export function CategoryShield({ label, color = "fill-primary", className }: CategoryShieldProps) {
+  return (
+    <div className={cn("relative w-8 h-8", className)}>
+      <svg viewBox="0 0 100 120" className={cn("w-full h-full", color)}>
+        <path d="M50 0L100 20v40c0 30-20 50-50 60C20 110 0 90 0 60V20L50 0z" />
+      </svg>
+      <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-white">
+        {label}
+      </span>
+    </div>
+  )
+}

--- a/components/store-integration.tsx
+++ b/components/store-integration.tsx
@@ -163,7 +163,7 @@ export function StoreSection() {
                 <div className="p-6">
                   <div className="flex items-center gap-2 mb-3">
                     <div className="flex items-center gap-1">
-                      <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                      <Star className="h-4 w-4 fill-primary text-primary" />
                       <span className="text-sm font-medium">{product.rating}</span>
                     </div>
                     <div className="flex items-center gap-1 text-charcoal-500 dark:text-charcoal-400">


### PR DESCRIPTION
## Summary
- add new `CategoryShield` component for course badges
- swap yellow highlights to orange to match site palette
- show shield badge on products
- recolor stars across site

## Testing
- `pnpm install`
- `pnpm lint` *(fails: `next` not found)*
- `pnpm build` *(fails to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd6b5c8c832c93acc512a2896b2d