### PR TITLE
Remove yellow color usage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -201,7 +201,7 @@ export default function EstudioVePage() {
           className="absolute inset-0 overflow-hidden pointer-events-none"
         >
           <div className="absolute top-1/4 right-1/4 w-96 h-96 bg-orange-500/10 rounded-full blur-3xl animate-pulse" />
-          <div className="absolute bottom-1/4 left-1/4 w-64 h-64 bg-yellow-400/10 rounded-full blur-2xl animate-pulse delay-1000" />
+          <div className="absolute bottom-1/4 left-1/4 w-64 h-64 bg-transparent border-2 border-orange-400/20 rounded-full blur-2xl animate-pulse delay-1000" />
         </motion.div>
 
         {/* Contenido principal */}
@@ -235,14 +235,14 @@ export default function EstudioVePage() {
               <div className="absolute inset-0 bg-gradient-to-r from-orange-600 to-orange-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </button>
 
-            <button className="group relative overflow-hidden bg-gradient-to-r from-yellow-400 to-yellow-500 hover:from-yellow-500 hover:to-yellow-600 text-black px-8 py-4 rounded-2xl text-lg font-semibold shadow-2xl transition-all duration-300 transform hover:scale-105 hover:shadow-yellow-500/25">
+            <button className="group relative overflow-hidden border border-orange-500 text-orange-500 bg-transparent px-8 py-4 rounded-2xl text-lg font-semibold shadow-2xl transition-all duration-300 transform hover:scale-105 hover:bg-orange-500/10">
               <span className="relative z-10 flex items-center justify-center gap-2">
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
                 Agendar mentoría
               </span>
-              <div className="absolute inset-0 bg-gradient-to-r from-yellow-500 to-yellow-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              <div className="absolute inset-0 bg-orange-500/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
             </button>
           </div>
 

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -522,7 +522,7 @@ export default function ProductosPage() {
                     <div className="p-6">
                       <div className="flex items-center gap-2 mb-3">
                         <div className="flex items-center gap-1">
-                          <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                          <Star className="h-4 w-4 fill-orange-400 text-orange-400" />
                           <span className="text-sm font-medium">{product.rating}</span>
                         </div>
                         <div className="flex items-center gap-1 text-charcoal-500 dark:text-charcoal-400">

--- a/app/servicios/page.tsx
+++ b/app/servicios/page.tsx
@@ -567,7 +567,7 @@ export default function ServiciosPage() {
                         {/* Service Info */}
                         <div className="flex items-center gap-4 mb-4 text-sm text-charcoal-500 dark:text-charcoal-400">
                           <div className="flex items-center gap-1">
-                            <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                            <Star className="h-4 w-4 fill-orange-400 text-orange-400" />
                             <span>{service.rating}</span>
                           </div>
                           <div className="flex items-center gap-1">

--- a/components/store-integration.tsx
+++ b/components/store-integration.tsx
@@ -163,7 +163,7 @@ export function StoreSection() {
                 <div className="p-6">
                   <div className="flex items-center gap-2 mb-3">
                     <div className="flex items-center gap-1">
-                      <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                      <Star className="h-4 w-4 fill-orange-400 text-orange-400" />
                       <span className="text-sm font-medium">{product.rating}</span>
                     </div>
                     <div className="flex items-center gap-1 text-charcoal-500 dark:text-charcoal-400">


### PR DESCRIPTION
## Summary
- restyle initial page decorative dot and mentorship button without yellow
- switch star rating icons to orange in product, service, and store integration pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e228af18832cb66d9b5e325762b6