### PR TITLE
Update header links

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react"
 import { useTheme } from "next-themes"
 import { DarkModeToggle } from "@/components/dark-mode-toggle"
+import { usePathname } from "next/navigation"
 
 interface BlogPost {
   id: string
@@ -149,6 +150,7 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
   const [likes, setLikes] = useState(0)
   const [readingProgress, setReadingProgress] = useState(0)
   const { theme } = useTheme()
+  const pathname = usePathname()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -270,16 +272,19 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
             <nav className="hidden md:flex items-center space-x-8">
               <Link
                 href="/"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
               >
                 Inicio
               </Link>
-              <Link href="/blog" className="text-primary font-medium">
+              <Link
+                href="/blog"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/blog") ? "text-primary font-semibold" : ""}`}
+              >
                 Blog
               </Link>
               <Link
                 href="/productos"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
               >
                 Productos
               </Link>
@@ -313,16 +318,19 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
               <nav className="flex flex-col space-y-4 pt-4">
                 <Link
                   href="/"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
                 >
                   Inicio
                 </Link>
-                <Link href="/blog" className="text-left text-primary font-medium">
+                <Link
+                  href="/blog"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/blog") ? "text-primary font-semibold" : ""}`}
+                >
                   Blog
                 </Link>
                 <Link
                   href="/productos"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
                 >
                   Productos
                 </Link>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Calendar, Clock, User, Search, Filter, ArrowLeft, Eye, Heart, Menu, X } from "lucide-react"
 import { useTheme } from "next-themes"
 import { DarkModeToggle } from "@/components/dark-mode-toggle"
+import { usePathname } from "next/navigation"
 
 interface BlogPost {
   id: string
@@ -127,6 +128,7 @@ export default function BlogPage() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const { theme, setTheme } = useTheme()
+  const pathname = usePathname()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -210,19 +212,19 @@ export default function BlogPage() {
             <nav className="hidden md:flex items-center space-x-8">
               <Link
                 href="/"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
               >
                 Inicio
               </Link>
               <Link
-                href="/#servicios"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                href="/servicios"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/servicios") ? "text-primary font-semibold" : ""}`}
               >
                 Servicios
               </Link>
               <Link
                 href="/productos"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
               >
                 Productos
               </Link>
@@ -256,19 +258,19 @@ export default function BlogPage() {
               <nav className="flex flex-col space-y-4 pt-4">
                 <Link
                   href="/"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
                 >
                   Inicio
                 </Link>
                 <Link
-                  href="/#servicios"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  href="/servicios"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/servicios") ? "text-primary font-semibold" : ""}`}
                 >
                   Servicios
                 </Link>
                 <Link
                   href="/productos"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
                 >
                   Productos
                 </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,11 +34,13 @@ import {
   Rocket,
 } from "lucide-react"
 import { useTheme } from "next-themes"
+import { usePathname } from "next/navigation"
 
 export default function EstudioVePage() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const { theme, setTheme } = useTheme()
+  const pathname = usePathname()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -83,12 +85,12 @@ export default function EstudioVePage() {
 
             {/* Desktop Navigation */}
             <nav className="hidden md:flex items-center space-x-8">
-              <button
-                onClick={() => scrollToSection("servicios")}
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+              <Link
+                href="/servicios"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/servicios") ? "text-primary font-semibold" : ""}`}
               >
                 Servicios
-              </button>
+              </Link>
               <button
                 onClick={() => scrollToSection("sobre-nosotros")}
                 className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
@@ -97,7 +99,7 @@ export default function EstudioVePage() {
               </button>
               <Link
                 href="/productos"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
               >
                 Productos
               </Link>
@@ -136,12 +138,12 @@ export default function EstudioVePage() {
           {isMobileMenuOpen && (
             <div className="md:hidden mt-4 pb-4 border-t border-charcoal-200/20 dark:border-charcoal-700/20 animate-slide-up">
               <nav className="flex flex-col space-y-4 pt-4">
-                <button
-                  onClick={() => scrollToSection("servicios")}
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                <Link
+                  href="/servicios"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/servicios") ? "text-primary font-semibold" : ""}`}
                 >
                   Servicios
-                </button>
+                </Link>
                 <button
                   onClick={() => scrollToSection("sobre-nosotros")}
                   className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
@@ -150,7 +152,7 @@ export default function EstudioVePage() {
                 </button>
                 <Link
                   href="/productos"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
                 >
                   Productos
                 </Link>

--- a/app/productos/page.tsx
+++ b/app/productos/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react"
 import { useTheme } from "next-themes"
 import { DarkModeToggle } from "@/components/dark-mode-toggle"
+import { usePathname } from "next/navigation"
 
 interface Product {
   id: string
@@ -156,6 +157,7 @@ export default function ProductosPage() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const { theme, setTheme } = useTheme()
+  const pathname = usePathname()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -289,13 +291,13 @@ export default function ProductosPage() {
             <nav className="hidden md:flex items-center space-x-8">
               <Link
                 href="/"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
               >
                 Inicio
               </Link>
               <Link
-                href="/#servicios"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                href="/servicios"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/servicios") ? "text-primary font-semibold" : ""}`}
               >
                 Servicios
               </Link>
@@ -335,13 +337,13 @@ export default function ProductosPage() {
               <nav className="flex flex-col space-y-4 pt-4">
                 <Link
                   href="/"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
                 >
                   Inicio
                 </Link>
                 <Link
-                  href="/#servicios"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  href="/servicios"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/servicios") ? "text-primary font-semibold" : ""}`}
                 >
                   Servicios
                 </Link>

--- a/app/servicios/page.tsx
+++ b/app/servicios/page.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react"
 import { useTheme } from "next-themes"
 import { DarkModeToggle } from "@/components/dark-mode-toggle"
+import { usePathname } from "next/navigation"
 
 interface Service {
   id: string
@@ -261,6 +262,7 @@ export default function ServiciosPage() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const { theme } = useTheme()
+  const pathname = usePathname()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -337,7 +339,7 @@ export default function ServiciosPage() {
             <nav className="hidden md:flex items-center space-x-8">
               <Link
                 href="/"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
               >
                 Inicio
               </Link>
@@ -349,13 +351,13 @@ export default function ServiciosPage() {
               </Link>
               <Link
                 href="/productos"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
               >
                 Productos
               </Link>
               <Link
                 href="/blog"
-                className="text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                className={`text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/blog") ? "text-primary font-semibold" : ""}`}
               >
                 Blog
               </Link>
@@ -389,7 +391,7 @@ export default function ServiciosPage() {
               <nav className="flex flex-col space-y-4 pt-4">
                 <Link
                   href="/"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname === "/" ? "text-primary font-semibold" : ""}`}
                 >
                   Inicio
                 </Link>
@@ -401,13 +403,13 @@ export default function ServiciosPage() {
                 </Link>
                 <Link
                   href="/productos"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/productos") ? "text-primary font-semibold" : ""}`}
                 >
                   Productos
                 </Link>
                 <Link
                   href="/blog"
-                  className="text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium"
+                  className={`text-left text-charcoal-600 dark:text-charcoal-300 hover:text-primary transition-colors duration-300 font-medium ${pathname.startsWith("/blog") ? "text-primary font-semibold" : ""}`}
                 >
                   Blog
                 </Link>


### PR DESCRIPTION
## Summary
- ensure header links maintain active state across pages
- route "Servicios" nav link to `/servicios`

## Testing
- `pnpm install`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6840e49b2798832c94205d4c118101db